### PR TITLE
Handle no internet connection when pulling to refresh

### DIFF
--- a/app/src/main/java/ello/co/ello/MainActivity.java
+++ b/app/src/main/java/ello/co/ello/MainActivity.java
@@ -28,7 +28,10 @@ public class MainActivity
     }
 
     @Override public void onRefresh() {
-        if(mWebView != null) {
+        if(!Reachability.isNetworkConnected(this)) {
+            displayScreenContent();
+        }
+        else if(mWebView != null) {
             mWebView.reload();
         }
         mSwipeLayout.setRefreshing(false);


### PR DESCRIPTION
This fixes the issue of seeing a browser error when the user pulls to refresh when the device does not have an internet connection. Before reloading the page we check for an internet connection. If one is not present we show the native no internet screen.