### PR TITLE
Add deep linking for preview.ello.co

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,8 +21,13 @@
             android:theme="@style/Theme.AppCompat.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="preview.ello.co"/>
             </intent-filter>
         </activity>
         <activity
@@ -30,7 +35,6 @@
             android:theme="@style/SplashTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/ello/co/ello/MainActivity.java
+++ b/app/src/main/java/ello/co/ello/MainActivity.java
@@ -2,6 +2,7 @@ package ello.co.ello;
 
 import android.content.Intent;
 import android.graphics.Bitmap;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBarActivity;
@@ -15,6 +16,7 @@ public class MainActivity
 
     private AdvancedWebView mWebView;
     private SwipeRefreshLayout mSwipeLayout;
+    private String path = "https://preview.ello.co";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -25,6 +27,7 @@ public class MainActivity
         if (savedInstanceState == null) {
             displayScreenContent();
         }
+        deepLinkWhenPresent();
     }
 
     @Override public void onRefresh() {
@@ -43,6 +46,7 @@ public class MainActivity
         if(!Reachability.isNetworkConnected(this) || mWebView == null) {
             displayScreenContent();
         }
+        deepLinkWhenPresent();
     }
 
     @Override
@@ -70,6 +74,18 @@ public class MainActivity
         }
     }
 
+    private void deepLinkWhenPresent(){
+        Intent intent = getIntent();
+        Uri data = intent.getData();
+
+        if (data != null) {
+            path = data.toString();
+            if (mWebView != null) {
+                mWebView.loadUrl(path);
+            }
+        }
+    }
+
     private void displayScreenContent() {
         if(Reachability.isNetworkConnected(this)) {
             setupWebView();
@@ -87,7 +103,7 @@ public class MainActivity
         mWebView = (AdvancedWebView) findViewById(R.id.activity_main_webview);
         mWebView.setAlpha(0.0f);
         mWebView.setListener(this, this);
-        mWebView.loadUrl("https://preview.ello.co");
+        mWebView.loadUrl(path);
         mWebView.setWebViewClient(new ElloWebViewClient(this));
     }
 


### PR DESCRIPTION
Deeplinking is dead simple on Android. Kind of amazing given the hassle it is on iOS. The fact that we're loading URLs in a `WebView` helps too. When a deep link is tapped we forward the url to the `WebView`. Doesn't get much simpler than that. :tada: 

Note that we'll need to change `preview.ello.co` to something else when we're ready to go live.

![deep-link-1](https://cloud.githubusercontent.com/assets/12459/13889923/a5b26a50-ed0e-11e5-9c9b-e04bdd0d6d0c.jpg)
![deep-link-2](https://cloud.githubusercontent.com/assets/12459/13889926/a8152698-ed0e-11e5-8fb1-627a8591a5ae.jpg)
