### PR TITLE
Add .ninja support

### DIFF
--- a/app/src/main/java/co/ello/ElloApp/ElloURI.java
+++ b/app/src/main/java/co/ello/ElloApp/ElloURI.java
@@ -5,7 +5,7 @@ public class ElloURI {
     private final static String TAG = ElloURI.class.getSimpleName();
 
     public static boolean shouldLoadInApp(String url) {
-        if (url.matches("^(https?://)?((w{3}|preview.)?ello.co|(ello-webapp-epic|ello-webapp-rainbow|ello-fg-stage1|ello-fg-stage2).herokuapp.com)/?\\S*$")) {
+        if (url.matches("^(https?://)?((w{3}|preview.)?ello.(co|ninja)|(ello-webapp-epic|ello-webapp-rainbow|ello-fg-stage1|ello-fg-stage2).herokuapp.com)/?\\S*$")) {
             return true;
         }
         else if (url.matches("/\\S*$")) {

--- a/app/src/test/java/co/ello/ElloApp/ElloURITest.java
+++ b/app/src/test/java/co/ello/ElloApp/ElloURITest.java
@@ -23,6 +23,7 @@ public class ElloURITest {
     @Test
     public void testShouldLoadInAppSucceeds() {
         assertTrue("https://ello.co should load in app", ElloURI.shouldLoadInApp("https://ello.co"));
+        assertTrue("https://ello.ninja should load in app", ElloURI.shouldLoadInApp("https://ello.ninja"));
         assertTrue("https://ello-webapp-epic.herokuapp.com should load in app", ElloURI.shouldLoadInApp("https://ello-webapp-epic.herokuapp.com"));
         assertTrue("https://ello-webapp-rainbow.herokuapp.com should load in app", ElloURI.shouldLoadInApp("https://ello-webapp-rainbow.herokuapp.com"));
         assertTrue("https://ello.co/sean should load in app", ElloURI.shouldLoadInApp("https://ello.co/sean"));


### PR DESCRIPTION
Prior to now we've not been able to use `https://ello.ninja` due to `ElloURI` not allowing the app to open `ello.ninja` urls. This PR fixes that issue.