### PR TITLE
Force Picasso not to store images in its cache

### DIFF
--- a/app/app.iml
+++ b/app/app.iml
@@ -36,7 +36,6 @@
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/google-services/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
@@ -44,6 +43,7 @@
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/apt/test/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
@@ -86,18 +86,19 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/animated-vector-drawable/23.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/design/23.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/23.3.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-compat/24.2.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-core-ui/24.2.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-core-utils/24.2.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-fragment/24.2.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-media-compat/24.2.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/24.2.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-compat/25.1.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-core-ui/25.1.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-core-utils/25.1.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-fragment/25.1.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-media-compat/25.1.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/25.1.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-vector-drawable/23.3.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services-base/9.2.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.android.gms/play-services-basement/9.2.0/jars" />
@@ -110,13 +111,20 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.firebase/firebase-core/9.2.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.google.firebase/firebase-iid/9.2.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.nispok/snackbar/2.11.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/org.xwalk/xwalk_core_library_beta/19.49.514.2/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/org.xwalk/xwalk_core_library/22.52.561.4/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-resources" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
@@ -126,15 +134,12 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="support-v4-24.2.0" level="project" />
-    <orderEntry type="library" exported="" name="support-compat-24.2.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="assertj-core-1.7.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-base-9.2.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-library-1.3" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="asm-commons-5.0.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="accessibility-test-framework-2.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="shadows-support-v4-3.0" level="project" />
-    <orderEntry type="library" exported="" name="support-fragment-24.2.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="asm-5.0.1" level="project" />
     <orderEntry type="library" exported="" name="recyclerview-v7-23.3.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="shadows-core-3.1" level="project" />
@@ -146,14 +151,18 @@
     <orderEntry type="library" exported="" name="appcompat-v7-23.3.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-gcm-9.2.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="icu4j-53.1" level="project" />
-    <orderEntry type="library" exported="" name="support-core-ui-24.2.0" level="project" />
+    <orderEntry type="library" exported="" name="xwalk_core_library-22.52.561.4" level="project" />
     <orderEntry type="library" exported="" name="play-services-tasks-9.2.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="robolectric-resources-3.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="asm-tree-5.0.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="sqlite4java-0.282" level="project" />
     <orderEntry type="library" exported="" name="firebase-analytics-impl-9.2.0" level="project" />
+    <orderEntry type="library" exported="" name="support-v4-25.1.1" level="project" />
+    <orderEntry type="library" exported="" name="support-compat-25.1.1" level="project" />
+    <orderEntry type="library" exported="" name="support-media-compat-25.1.1" level="project" />
     <orderEntry type="library" exported="" name="dagger-2.3" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="mockito-core-2.0.54-beta" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-25.1.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="robolectric-3.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="maven-ant-tasks-2.1.3" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="ant-1.8.0" level="project" />
@@ -162,23 +171,22 @@
     <orderEntry type="library" exported="" scope="TEST" name="ant-launcher-1.8.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="xpp3_min-1.1.4c" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="xstream-1.4.8" level="project" />
-    <orderEntry type="library" exported="" name="xwalk_core_library_beta-19.49.514.2" level="project" />
+    <orderEntry type="library" exported="" name="support-core-ui-25.1.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="asm-util-5.0.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="bcprov-jdk16-1.46" level="project" />
     <orderEntry type="library" exported="" name="jsr250-api-1.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="opengl-api-gl1.1-android-2.1_r1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="objenesis-2.1" level="project" />
+    <orderEntry type="library" exported="" name="support-core-utils-25.1.1" level="project" />
+    <orderEntry type="library" exported="" name="support-fragment-25.1.1" level="project" />
     <orderEntry type="library" exported="" name="firebase-core-9.2.0" level="project" />
     <orderEntry type="library" exported="" name="snackbar-2.11.0" level="project" />
-    <orderEntry type="library" exported="" name="support-media-compat-24.2.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="robolectric-annotations-3.1" level="project" />
     <orderEntry type="library" exported="" name="play-services-basement-9.2.0" level="project" />
     <orderEntry type="library" exported="" name="play-services-iid-9.2.0" level="project" />
-    <orderEntry type="library" exported="" name="support-core-utils-24.2.0" level="project" />
     <orderEntry type="library" exported="" name="javax.inject-1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="byte-buddy-1.3.16" level="project" />
     <orderEntry type="library" exported="" name="design-23.3.0" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-24.2.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="robolectric-utils-3.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="asm-analysis-5.0.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="protobuf-java-2.6.1" level="project" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,8 +17,8 @@ android {
         applicationId "co.ello.ElloApp"
         minSdkVersion 16
         targetSdkVersion 23
-        versionCode 24
-        versionName "1.3"
+        versionCode 25
+        versionName "1.3.1"
     }
     buildTypes {
         release {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     compile "com.android.support:appcompat-v7:23.3.0"
     compile "com.android.support:support-v4:23.3.0"
     compile "com.android.support:design:23.3.0"
-    compile 'org.xwalk:xwalk_core_library_beta:19.49.514.2'
+    compile 'org.xwalk:xwalk_core_library:22.52.561.4'
     testApt 'com.google.guava:guava:19.0'
     testApt 'com.google.dagger:dagger-compiler:2.3'
     testCompile 'junit:junit:4.10'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
-        android:name=".Dagger.ElloApp">
+        android:name=".Dagger.ElloApp"
+        android:largeHeap="true">
         <activity
             android:name=".MainActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"

--- a/app/src/main/java/co/ello/ElloApp/MainActivity.java
+++ b/app/src/main/java/co/ello/ElloApp/MainActivity.java
@@ -30,7 +30,6 @@ import com.nispok.snackbar.listeners.ActionClickListener;
 import com.squareup.picasso.MemoryPolicy;
 import com.squareup.picasso.NetworkPolicy;
 import com.squareup.picasso.Picasso;
-import static android.graphics.Bitmap.Config.RGB_565;
 
 import org.xwalk.core.JavascriptInterface;
 import org.xwalk.core.XWalkActivity;
@@ -263,7 +262,6 @@ public class MainActivity
             imageSelectedIntent = intent;
             Picasso.with(MainActivity.this)
                     .load(imageURI)
-                    .config(RGB_565)
                     .resize(1200, 3600)
                     .centerInside()
                     .onlyScaleDown()

--- a/app/src/main/java/co/ello/ElloApp/MainActivity.java
+++ b/app/src/main/java/co/ello/ElloApp/MainActivity.java
@@ -27,7 +27,10 @@ import com.nispok.snackbar.Snackbar;
 import com.nispok.snackbar.SnackbarManager;
 import com.nispok.snackbar.enums.SnackbarType;
 import com.nispok.snackbar.listeners.ActionClickListener;
+import com.squareup.picasso.MemoryPolicy;
+import com.squareup.picasso.NetworkPolicy;
 import com.squareup.picasso.Picasso;
+import static android.graphics.Bitmap.Config.RGB_565;
 
 import org.xwalk.core.JavascriptInterface;
 import org.xwalk.core.XWalkActivity;
@@ -72,6 +75,7 @@ public class MainActivity
     private BroadcastReceiver pushReceivedReceiver;
     private BroadcastReceiver imageResizeReceiver;
     private Boolean isXWalkReady = false;
+    private Boolean isPicking = false;
     private Intent imageSelectedIntent;
     private Date lastReloaded;
     TmpTarget target;
@@ -234,8 +238,15 @@ public class MainActivity
 
     @Override
     public void onTrimMemory(int level) {
+
         super.onTrimMemory(level);
-        if (level >= ComponentCallbacks2.TRIM_MEMORY_MODERATE) {
+        if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE) {
+            // This should happen automatically, but from some searching around, it
+            // seems like some phones don't always trigger a GC on low memory
+            System.gc();
+        }
+        // Don't reload if we've just selected an image
+        if (level >= ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL && !isPicking) {
             shouldReload = true;
         }
     }
@@ -244,16 +255,20 @@ public class MainActivity
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         target = new TmpTarget(this, "tmp.jpg");
 
+        isPicking = false;
+
         if (intent != null && intent.getData() != null) {
             Uri imageURI = intent.getData();
-            File bitmap = new File(imageURI.toString());
 
             imageSelectedIntent = intent;
             Picasso.with(MainActivity.this)
                     .load(imageURI)
+                    .config(RGB_565)
                     .resize(1200, 3600)
                     .centerInside()
                     .onlyScaleDown()
+                    .networkPolicy(NetworkPolicy.NO_CACHE, NetworkPolicy.NO_STORE)
+                    .memoryPolicy(MemoryPolicy.NO_CACHE, MemoryPolicy.NO_STORE)
                     .into(target);
         }
         else {
@@ -281,6 +296,10 @@ public class MainActivity
             progress.dismiss();
         }
         registerForGCM();
+    }
+
+    public void setIsPicking() {
+        isPicking = true;
     }
 
     private void setupRegisterDeviceReceiver() {
@@ -510,11 +529,14 @@ public class MainActivity
                 String acceptType,
                 String capture)
         {
+            Context context = view.getContext();
+            if (context instanceof MainActivity) {
+                ((MainActivity)context).setIsPicking();
+            }
             boolean hasPermission = checkPermissions();
             if(hasPermission) {
                 super.openFileChooser(view, uploadMsg, acceptType, capture);
-            }
-            else {
+            } else {
                 this.view = view;
                 this.uploadMsg = uploadMsg;
                 this.acceptType = acceptType;

--- a/app/src/main/java/co/ello/ElloApp/TmpTarget.java
+++ b/app/src/main/java/co/ello/ElloApp/TmpTarget.java
@@ -41,7 +41,7 @@ public class TmpTarget implements Target
             if(savedFile != null) {
                 Uri webURI = Uri.fromFile(savedFile);
                 Intent imageResized = new Intent(ElloPreferences.IMAGE_RESIZED);
-                if(webURI != null) {
+                if (webURI != null) {
                     imageResized.putExtra("RESIZED_IMAGE_PATH", webURI.getPath());
                     context.sendBroadcast(imageResized);
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-beta1'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.google.gms:google-services:3.0.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     }


### PR DESCRIPTION
Some combination of the picker showing and the image resizing is causing memory pressure, which would result in a trim event being fired and the page being reloaded in the middle of the upload process.

This does a few things to address that:

- Update Crosswalk to the latest stable (22.52.561.4)
- Set the `android:largeheap` setting in the manifest
- Use the `RGB_565` setting for image reprocessing in Picasso
- Prevent `trimMemory` events from triggering a reload while picking images

It does now seem that the Crosswalk picker does not return the image capture intent back properly in a way that the image gets processed, which appears to be unrelated but could also cause memory pressure.